### PR TITLE
allow default shared secret to be set on github gateway

### DIFF
--- a/charts/brigade-github-app/templates/deployment.yaml
+++ b/charts/brigade-github-app/templates/deployment.yaml
@@ -39,6 +39,13 @@ spec:
             value: "{{ .Values.github.appID }}"
           - name: CHECK_SUITE_ON_PR
             value: "{{ .Values.github.checkSuiteOnPR }}"
+          {{- if .Values.github.defaultSharedSecret }}
+          - name: DEFAULT_SHARED_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ $fullname }}
+                key: defaultSharedSecret
+          {{- end }}
         volumeMounts:
           - name: github-config
             mountPath: /etc/brigade-github-app

--- a/charts/brigade-github-app/templates/secret.yaml
+++ b/charts/brigade-github-app/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.github.defaultSharedSecret }}
+{{ $fullname :=  include "gateway.fullname" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullname }}
+  labels:
+    app: {{ $fullname }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+stringData:
+  defaultSharedSecret: {{ .Values.github.defaultSharedSecret }}
+{{- end }}

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -52,3 +52,4 @@ github:
   # Trigger a Check Suite on Pull Requests
   # This will need to be set to true to enable running Check Suites on PRs originating from forks
   checkSuiteOnPR: true
+  # defaultSharedSecret:

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -52,4 +52,7 @@ github:
   # Trigger a Check Suite on Pull Requests
   # This will need to be set to true to enable running Check Suites on PRs originating from forks
   checkSuiteOnPR: true
+  ## Set a defaultSharedSecret if you want to use this one instance of the
+  ## Github gateway with multiple Brigade projects. Leave the shared secret field
+  ## blank in project-level configuration and this default will be used.
   # defaultSharedSecret:


### PR DESCRIPTION
Complements https://github.com/brigadecore/brigade-github-app/pull/54

__Edit:__ _After_ we do the next release of this gw chart, I want to make the `brigade` chart depend on that latest release and then surface this new setting there as well.