### PR TITLE
improve yaml formatting

### DIFF
--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -1,12 +1,12 @@
-# Set this to true to enable Kubernetes RBAC support (recommended)
 rbac:
+  ## Set this to true to enable Kubernetes RBAC support (recommended)
   enabled: false
 
 serviceAccount:
   create: true
   name: 
 
-# Image configuration
+## Image configuration
 registry: brigadecore
 name: brigade-github-app
 tag: latest
@@ -20,35 +20,35 @@ service:
 
 ingress:
   enabled: true
-  # Used to create an Ingress record.
+  ## Used to create an Ingress record.
   hosts:
-    - gh-app.example.com
+  - gh-app.example.com
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
   tls:
-    # Secrets must be manually created in the namespace.
-    - secretName: gh-app-tls
-      hosts:
-      - gh-app.example.com
+  ## Secrets must be manually created in the namespace.
+  - secretName: gh-app-tls
+    hosts:
+    - gh-app.example.com
 
 gateway:
-  # The author associations who are allowed to have PRs built
-  # Classes are: COLLABORATOR, CONTRIBUTOR, OWNER, NONE, MEMBER, FIRST_TIMER, FIRST_TME_CONTRIBUTOR
-  # See https://developer.github.com/v4/enum/commentauthorassociation/
-  # To completely disable pull request builds, leave this list blank.
+  ## The author associations who are allowed to have PRs built
+  ## Classes are: COLLABORATOR, CONTRIBUTOR, OWNER, NONE, MEMBER, FIRST_TIMER, FIRST_TME_CONTRIBUTOR
+  ## See https://developer.github.com/v4/enum/commentauthorassociation/
+  ## To completely disable pull request builds, leave this list blank.
   allowedAuthorRoles:
-    - OWNER
-    - MEMBER
-    - COLLABORATOR
+  - OWNER
+  - MEMBER
+  - COLLABORATOR
 
 github:
-  # The x509 PEM-formatted keyfile GitHub issued for you App.
+  ## The x509 PEM-formatted keyfile GitHub issued for you App.
   key: |
     REQUIRED: Your key goes here.
-  # This represents the unique ID for a GitHub App
-  # The value can be retrieved from the main App page or any inbound webhook payloads
+  ## This represents the unique ID for a GitHub App
+  ## The value can be retrieved from the main App page or any inbound webhook payloads
   appID:
-  # Trigger a Check Suite on Pull Requests
-  # This will need to be set to true to enable running Check Suites on PRs originating from forks
+  ## Trigger a Check Suite on Pull Requests
+  ## This will need to be set to true to enable running Check Suites on PRs originating from forks
   checkSuiteOnPR: true

--- a/charts/brigade-github-oauth/values.yaml
+++ b/charts/brigade-github-oauth/values.yaml
@@ -1,49 +1,49 @@
 registry: brigadecore
 name: brigade-github-gateway
-# Note: tag is currently pinned to v0.20.0, the last release of this gateway, via appVersion in this chart's Chart.yaml
-# Be sure the tag exists when changing this value
-#tag:
-#pullPolicy: IfNotPresent
+## Note: tag is currently pinned to v0.20.0, the last release of this gateway, via appVersion in this chart's Chart.yaml
+## Be sure the tag exists when changing this value
+# tag:
+# pullPolicy: IfNotPresent
 
 rbac:
   enabled: true
 
-# The author associations who are allowed to have PRs built
-# Classes are: COLLABORATOR, CONTRIBUTOR, OWNER, NONE, MEMBER, FIRST_TIMER, FIRST_TME_CONTRIBUTOR
-# See https://developer.github.com/v4/enum/commentauthorassociation/
-# To completely disable pull request builds, leave this list blank.
+## The author associations who are allowed to have PRs built
+## Classes are: COLLABORATOR, CONTRIBUTOR, OWNER, NONE, MEMBER, FIRST_TIMER, FIRST_TME_CONTRIBUTOR
+## See https://developer.github.com/v4/enum/commentauthorassociation/
+## To completely disable pull request builds, leave this list blank.
 allowedAuthorRoles:
-  - OWNER
-  - MEMBER
-  - COLLABORATOR
+- OWNER
+- MEMBER
+- COLLABORATOR
 
 serviceAccount:
   create: true
   name:
 
-# The service is for the Brigade gateway. If you do not want to have Brigade
-# listening for incomming GitHub requests, disable this.
+## The service is for the Brigade gateway. If you do not want to have Brigade
+## listening for incomming GitHub requests, disable this.
 service:
   name: github-oauth-gateway
   type: LoadBalancer
   externalPort: 7744
   internalPort: 7744
-# By default, this is off. If you enable it, you might want to change the
-# service.type to ClusterIP
-# Configure liveness probes except `httpGet`
-#livenessProbe:
-#  initialDelaySeconds: 20
-# Configure readiness probes except `httpGet`
-#readinessProbe:
-#  initialDelaySeconds: 20
+## By default, this is off. If you enable it, you might want to change the
+## service.type to ClusterIP
+## Configure liveness probes except `httpGet`
+# livenessProbe:
+#   initialDelaySeconds: 20
+## Configure readiness probes except `httpGet`
+# readinessProbe:
+#   initialDelaySeconds: 20
 
 ingress:
   enabled: false
   hosts: []
   paths:
   - /
-  # Add TLS configuration
+  ## Add TLS configuration
   # tls: <TLS_CONFIG>
-  # Add custom annotations
+  ## Add custom annotations
   # annotations:
   #   name: value

--- a/charts/brigade-k8s-gateway/values.yaml
+++ b/charts/brigade-k8s-gateway/values.yaml
@@ -1,48 +1,48 @@
-# Set this to true to enable Kubernetes RBAC support (recommended)
 rbac:
+  ## Set this to true to enable Kubernetes RBAC support (recommended)
   enabled: false
 
-# Image configuration
+## Image configuration
 registry: brigadecore
 name: brigade-k8s-gateway
 tag: latest
 pullPolicy: "IfNotPresent"
 
-# What to watch
+## What to watch
 project: brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac
 
-# Define the filters that you want to run.
-# Filters are evaluated in order (top to bottom). Every filter must either
-# 'accept' or 'reject' an event. The final rule is the default rule, and
-# is typically merely of the form '- action: accept' or '- action: reject'
-#
-# The keys you can use in a filter are:
-# - kind: (Pod or Node) - the Kubernetes kind. Events are only emitted for pod and node.
-# - namespace: (Pod only) - the namespace to listen to
-# - action: (reject, accept) - whether to accept or reject the event. If it is rejected, no Brigade build is started
-# - reasons: (Killing, Starting, ...) - a list of reasons that you want to listen for.
-#   Unfortunately, the precise list of reasons is not defined in Kubernetes.
-#
-# THESE ARE EXAMPLES.
-# Our suggestion is that you ALWAYS set up Brigade in its own namespace, and
-# then `reject` on any pod event in that namespace. Otherwise each time you
-# trigger a build or job it will trigger another event, which will trigger another
-# build, which will trigger another build, which will trigger another build....
+## Define the filters that you want to run.
+## Filters are evaluated in order (top to bottom). Every filter must either
+## 'accept' or 'reject' an event. The final rule is the default rule, and
+## is typically merely of the form '- action: accept' or '- action: reject'
+##
+## The keys you can use in a filter are:
+## - kind: (Pod or Node) - the Kubernetes kind. Events are only emitted for pod and node.
+## - namespace: (Pod only) - the namespace to listen to
+## - action: (reject, accept) - whether to accept or reject the event. If it is rejected, no Brigade build is started
+## - reasons: (Killing, Starting, ...) - a list of reasons that you want to listen for.
+##   Unfortunately, the precise list of reasons is not defined in Kubernetes.
+##
+## THESE ARE EXAMPLES.
+## Our suggestion is that you ALWAYS set up Brigade in its own namespace, and
+## then `reject` on any pod event in that namespace. Otherwise each time you
+## trigger a build or job it will trigger another event, which will trigger another
+## build, which will trigger another build, which will trigger another build....
 filters:
-  # Ignore all events coming from kube-system
-  - namespace: kube-system
-    action: reject
-  # Ignore events on Nodes. We just care about Pods
-  - kind: Node
-    action: reject
-  # Ignore "Killing" messages for Pods
-  - kind: Pod
-    reasons:
-      - Killing
-    action: reject
-  # ONLY Listen to events for Pods in this namespace
-  - kind: Pod
-    namespace: pequod
-    action: accept
-  # Reject anything else (don't DOS yourself)
-  - action: reject
+## Ignore all events coming from kube-system
+- namespace: kube-system
+  action: reject
+## Ignore events on Nodes. We just care about Pods
+- kind: Node
+  action: reject
+## Ignore "Killing" messages for Pods
+- kind: Pod
+  reasons:
+    - Killing
+  action: reject
+## ONLY Listen to events for Pods in this namespace
+- kind: Pod
+  namespace: pequod
+  action: accept
+## Reject anything else (don't DOS yourself)
+- action: reject

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -1,18 +1,18 @@
-# Name of the project, in the form "user/project"
+## Name of the project, in the form "user/project"
 project: "brigadecore/empty-testbed"
 
-# Domain/Org/Project
+## Domain/Org/Project
 repository: "github.com/brigadecore/empty-testbed"
 
-# The definitive clone URL. This can be any Git-supported URL format.
-# You may set this to "" for no clone URL.
+## The definitive clone URL. This can be any Git-supported URL format.
+## You may set this to "" for no clone URL.
 cloneURL: "https://github.com/brigadecore/empty-testbed.git"
 
-# OPTIONAL: initGitSubmodules will recursively initialize all submodules in the repository. Default: false
+## OPTIONAL: initGitSubmodules will recursively initialize all submodules in the repository. Default: false
 # initGitSubmodules: "false"
 
-# OPTIONAL: defaultScript is the brigade.js used by default when your VCS repo misses a brigade.js
-# in it.
+## OPTIONAL: defaultScript is the brigade.js used by default when your VCS repo misses a brigade.js
+## in it.
 # defaultScript: |
 #   const { events, Job } = require("brigadier")
 #   function run(e, project) {
@@ -20,75 +20,75 @@ cloneURL: "https://github.com/brigadecore/empty-testbed.git"
 #   }
 #   events.on("run", run)
 
-# OPTIONAL: defaultScriptName is the name of a configmap used as a fallback brigade.js.
+## OPTIONAL: defaultScriptName is the name of a configmap used as a fallback brigade.js.
 # defaultScriptName: default-script-cm
 
 
-# Used by GitHub and other services to compute hook HMACs.
+## Used by GitHub and other services to compute hook HMACs.
 sharedSecret: "IBrakeForSeaBeasts"
 
-# OPTIONAL: genericGatewaySecret is the secret that should be used on subsequent calls to the Generic Gateway in order to raise a "webhook" event for this Project
-# This is REQUIRED for the Generic Gateway, but optional otherwise.
+## OPTIONAL: genericGatewaySecret is the secret that should be used on subsequent calls to the Generic Gateway in order to raise a "webhook" event for this Project
+## This is REQUIRED for the Generic Gateway, but optional otherwise.
 genericGatewaySecret: "mygenericsecret"
 
-# OPTIONAL: Use this to have Brigade update your project about the build.
-# This is REQUIRED for the GitHub gateway, but optional otherwise.
+## OPTIONAL: Use this to have Brigade update your project about the build.
+## This is REQUIRED for the GitHub gateway, but optional otherwise.
 github:
-#   token: "github oauth token"
-#   ENTERPRISE: For enterprise GitHub customers, set both of these as well.
-#   baseURL: "https://internal.github.url/foo"
-#   uploadURL: "https://internal.github.url/foo"
+  # token: "github oauth token"
+  ## ENTERPRISE: For enterprise GitHub customers, set both of these as well.
+  # baseURL: "https://internal.github.url/foo"
+  # uploadURL: "https://internal.github.url/foo"
 
-# OPTIONAL: Use this for private repositories
-# This is the PRIVATE key that Brigade will use to clone a private repo.
-# You should generate a special key for this. Don't reuse another one.
+## OPTIONAL: Use this for private repositories
+## This is the PRIVATE key that Brigade will use to clone a private repo.
+## You should generate a special key for this. Don't reuse another one.
 # sshKey: |-
-#  -----BEGIN RSA PRIVATE KEY-----
-#  IIEpAIBAAKCAg1wyZD164xNLrANjRrcsbieLwHJ6fKD3LC19E...
-#  ...
-#  ...
-#  -----END RSA PRIVATE KEY-----
+  # -----BEGIN RSA PRIVATE KEY-----
+  # IIEpAIBAAKCAg1wyZD164xNLrANjRrcsbieLwHJ6fKD3LC19E...
+  # ...
+  # ...
+  # -----END RSA PRIVATE KEY-----
 
-# OPTIONAL: Items in the 'secrets' array can be mounted as environment variables by
-# the brigade.js
-#
-# Example:
-#
-# In JS, do this:
-#
-#   events.push = function(e, p) {
-#     j = new Job("example")
-#     j.env= {"MY_ENV_VAR": p.secrets.myVar}
-#   }
-#
-# And here, add this:
-#
-#   secrets:
-#     myVar: "super awesome"
-#
-# Inside of the job's pod, $MY_ENV_VAR = "super awesome"
+## OPTIONAL: Items in the 'secrets' array can be mounted as environment variables by
+## the brigade.js
+##
+## Example:
+##
+## In JS, do this:
+##
+##   events.push = function(e, p) {
+##     j = new Job("example")
+##     j.env= {"MY_ENV_VAR": p.secrets.myVar}
+##   }
+##
+## And here, add this:
+##
+##   secrets:
+##     myVar: "super awesome"
+##
+## Inside of the job's pod, $MY_ENV_VAR = "super awesome"
 secrets:
-  # Example:
+  ## Example:
   # username: hello
 
-# OPTIONAL: Namespace into which builds will be deployed.
-# Using this has implications for what you can access, so don't set this unless
-# you know what you are doing.
+## OPTIONAL: Namespace into which builds will be deployed.
+## Using this has implications for what you can access, so don't set this unless
+## you know what you are doing.
 # namespace: "default"
 
-# OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
-# The default sidecar uses Git to fetch a copy of the project.
-#
-# If this is not supplied, `brigadecore/git-sidecar:VERSION` will be used, where VERSION
-# is the version of this chart.
-#
-# If this is set to NONE, no sidecar is used.  This may improve performance
-# very slightly, but will break some gateways or cause the default script to
-# be used.
+## OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
+## The default sidecar uses Git to fetch a copy of the project.
+##
+## If this is not supplied, `brigadecore/git-sidecar:VERSION` will be used, where VERSION
+## is the version of this chart.
+##
+## If this is set to NONE, no sidecar is used.  This may improve performance
+## very slightly, but will break some gateways or cause the default script to
+## be used.
 # vcsSidecar: "brigadecore/git-sidecar:latest"
 
-# OPTIONAL: vcsSidecarResources defines the resources (limits/requests) for all
-# the init-containers to be created by the worker and the one for the worker itself
+## OPTIONAL: vcsSidecarResources defines the resources (limits/requests) for all
+## the init-containers to be created by the worker and the one for the worker itself
 # vcsSidecarResources:
 #   limits:
 #     cpu: "100m"
@@ -97,47 +97,47 @@ secrets:
 #     cpu: "100m"
 #     memory: "100Mi"
 
-# OPTIONAL: imagePullSecrets allows you to specify a comma-separated list of
-# image pull secrets that will be injected into the worker. With this, you can
-# use a vcsSidecar or worker image from an internal repository.
-# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## OPTIONAL: imagePullSecrets allows you to specify a comma-separated list of
+## image pull secrets that will be injected into the worker. With this, you can
+## use a vcsSidecar or worker image from an internal repository.
+## https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 # imagePullSecrets: foo
 
-# OPTIONAL: buildStorageSize is the size of the shared storage space used by the jobs
+## OPTIONAL: buildStorageSize is the size of the shared storage space used by the jobs
 # buildStorageSize: "50Mi"
 
-# Allow Jobs to run in privileged mode. This will allow features like
-# Docker-in-Docker. This must be set to true before turning allowHostMounts
-# on.
+## Allow Jobs to run in privileged mode. This will allow features like
+## Docker-in-Docker. This must be set to true before turning allowHostMounts
+## on.
 allowPrivilegedJobs: "true"
 
-# OPTIONAL: Use this to allow host mounted docker sockets in your jobs.
-# This is a big security risk if your project is public-facing; enable at your own risk.
+## OPTIONAL: Use this to allow host mounted docker sockets in your jobs.
+## This is a big security risk if your project is public-facing; enable at your own risk.
 # allowHostMounts: "true"
 
-# Kubernetes-specific configuration options.
+## Kubernetes-specific configuration options.
 kubernetes:
-  # OPTIONAL: Override the storage class used for storing job caches. This must
-  # point to a readWriteMany volume provisioner.
-  #cacheStorageClass: default
-  # OPTIONAL: Override the storage class used for build storage. This must
-  # point to a readWriteMany volume provisioner.
-  #buildStorageClass: default
+  ## OPTIONAL: Override the storage class used for storing job caches. This must
+  ## point to a readWriteMany volume provisioner.
+  # cacheStorageClass: default
+  # # OPTIONAL: Override the storage class used for build storage. This must
+  # # point to a readWriteMany volume provisioner.
+  # buildStorageClass: default
 
 ###
-# ADVANCED
+## ADVANCED
 ###
 
-# OPTIONAL: specify an alternative command that the worker pod should run on startup.
-# For example, if you want the typescript compiler to re-run, replace this with
-# 'yarn build-start'. The default is 'yarn -s start' (-s is for silent).
-# Uncomment the line below to increase logging verbosity.
+## OPTIONAL: specify an alternative command that the worker pod should run on startup.
+## For example, if you want the typescript compiler to re-run, replace this with
+## 'yarn build-start'. The default is 'yarn -s start' (-s is for silent).
+## Uncomment the line below to increase logging verbosity.
 # workerCommand: "yarn start"
 
-# OPTIONAL: Project-specific worker settings which takes precedence over brigade-wide settings
-# Useful when you want a specific brigade-worker image for running brigade.js of this project.
+## OPTIONAL: Project-specific worker settings which takes precedence over brigade-wide settings
+## Useful when you want a specific brigade-worker image for running brigade.js of this project.
 worker:
-  #registry: brigadecore
-  #name: brigade-worker
-  #tag:
-  #pullPolicy: IfNotPresent
+  # registry: brigadecore
+  # name: brigade-worker
+  # tag:
+  # pullPolicy: IfNotPresent

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -1,72 +1,72 @@
-# This is the main configuration file for the Brigade chart.
-# To override values here, specify them in your own YAML file, and override
-# during install or upgrade:
-#
-#    $ helm install -n brigade -f myValues.yaml brigade/brigade
-#
-# By default, the chart will install with RBAC. To install without
-# RBAC, set `rbac.enabled` to `false`.
-#
-# To enable the GitHub gateway, set `brigade-github-app.enabled` to `true`.
-# See brigadecore/brigade-gitub-app for steps to setup a Github App and add its configuration
-# to the sub-chart section below.
-#
-# Advanced Configuration
-#
-# Developers may wish to override the location of Docker images. For each
-# deployment, `registry` controls the image registry, and `name` controls
-# the image name. If unspecified, the Chart.yaml's appVersion field will be
-# used to pull the tag. If you override the `tag` value, that version will
-# be used instead.
-#
-# Note that when `rbac.enabled` is turned on, as is the default, the chart will
-# install a set of RBAC objects that are designed to give a moderate set of
-# permissions to the Brigade core components. However, even if RBACs are not
-# enabled, this chart will create service accounts for each entity that we
-# install. Security experts may prefer to apply their own RBACs instead of the
-# ones supplied by the chart.  Provided that the service accounts remain the
-# same, this chart should provide compatibility with custom rules.
+## This is the main configuration file for the Brigade chart.
+## To override values here, specify them in your own YAML file, and override
+## during install or upgrade:
+##
+##    $ helm install -n brigade -f myValues.yaml brigade/brigade
+##
+## By default, the chart will install with RBAC. To install without
+## RBAC, set `rbac.enabled` to `false`.
+##
+## To enable the GitHub gateway, set `brigade-github-app.enabled` to `true`.
+## See brigadecore/brigade-gitub-app for steps to setup a Github App and add its configuration
+## to the sub-chart section below.
+##
+## Advanced Configuration
+##
+## Developers may wish to override the location of Docker images. For each
+## deployment, `registry` controls the image registry, and `name` controls
+## the image name. If unspecified, the Chart.yaml's appVersion field will be
+## used to pull the tag. If you override the `tag` value, that version will
+## be used instead.
+##
+## Note that when `rbac.enabled` is turned on, as is the default, the chart will
+## install a set of RBAC objects that are designed to give a moderate set of
+## permissions to the Brigade core components. However, even if RBACs are not
+## enabled, this chart will create service accounts for each entity that we
+## install. Security experts may prefer to apply their own RBACs instead of the
+## ones supplied by the chart.  Provided that the service accounts remain the
+## same, this chart should provide compatibility with custom rules.
 
 #########################
 # Sub-chart configuration
 #########################
 
-# Kashti, the Brigade Dashboard, is enabled by default.
-#
-# These resources are included by way of a sub-chart dependency (see requirements.yaml)
-#
-# Further configurability of Kashti-specific values would also go here, e.g.
-# kashti:
-#   image:
-#     repository: myrepository
-#     ...
-#
-# For full configuration, see the kashti chart in this repository and its values.yaml.
+## Kashti, the Brigade Dashboard, is enabled by default.
+##
+## These resources are included by way of a sub-chart dependency (see requirements.yaml)
+##
+## Further configurability of Kashti-specific values would also go here, e.g.
+## kashti:
+##   image:
+##     repository: myrepository
+##     ...
+##
+## For full configuration, see the kashti chart in this repository and its values.yaml.
 kashti:
   enabled: true
 
-# Brigade Github App, the GitHub Gateway for Brigade, is disabled by default.
-#
-# These resources are included by way of a sub-chart dependency (see requirements.yaml)
-#
-# Further configurability of Brigade Github App-specific values would also go here, e.g.
-# brigade-github-app:
-#   github:
-#     appID: myGithubAppID
-#     ...
-#
-# For full configuration, see the brigade-github-app chart in this repository
+## Brigade Github App, the GitHub Gateway for Brigade, is disabled by default.
+##
+## These resources are included by way of a sub-chart dependency (see requirements.yaml)
+##
+## Further configurability of Brigade Github App-specific values would also go here, e.g.
+## brigade-github-app:
+##   github:
+##     appID: myGithubAppID
+##     ...
+##
+## For full configuration, see the brigade-github-app chart in this repository
 brigade-github-app:
   enabled: false
 
-# gw is the deprecated Oauth-based GitHub Gateway that shipped with Brigade <= v0.20
-#
-# Its alias has been preserved as `gw` to support legacy Brigade installations,
-# although the chart name is `brigade-github-oauth`.
-#
-# We recommend users switch to the fully-supported Brigade GitHub App (configured above) instead.
-#
-# For full configuration, see the brigade-github-oauth chart in this repository
+## gw is the deprecated Oauth-based GitHub Gateway that shipped with Brigade <= v0.20
+##
+## Its alias has been preserved as `gw` to support legacy Brigade installations,
+## although the chart name is `brigade-github-oauth`.
+##
+## We recommend users switch to the fully-supported Brigade GitHub App (configured above) instead.
+##
+## For full configuration, see the brigade-github-oauth chart in this repository
 gw:
   enabled: false
 
@@ -74,38 +74,38 @@ gw:
 # Brigade chart configuration
 #############################
 
-# IMPORTANT: The RBAC system is complex, and if you are using RBACs in your
-# cluster, you may need to evaluate existing rules and accounts in addition
-# to the rules created here.
+## IMPORTANT: The RBAC system is complex, and if you are using RBACs in your
+## cluster, you may need to evaluate existing rules and accounts in addition
+## to the rules created here.
 rbac:
   enabled: true
 
-# controller is the main event processor in Brigade.
+## controller is the main event processor in Brigade.
 controller:
   enabled: true
   registry: brigadecore
   name: brigade-controller
-  # tag should only be specified if you want to override Chart.appVersion
-  # The default tag is the value of .Chart.AppVersion
-  #tag:
-  #pullPolicy: IfNotPresent
-  #workerResources:
-  #  limits:
-  #    cpu:
-  #    memory:
-  #  requests:
-  #    cpu:
-  #    memory:
+  ## tag should only be specified if you want to override Chart.appVersion
+  ## The default tag is the value of .Chart.AppVersion
+  # tag:
+  # pullPolicy: IfNotPresent
+  # workerResources:
+  #   limits:
+  #     cpu:
+  #     memory:
+  #   requests:
+  #     cpu:
+  #     memory:
   serviceAccount:
     create: true
     name: 
 
-# api is the API server. It is technically not needed for the operation of the
-# Brigade controller, but it is used by tools to learn about the state of the
-# cluster.
-#
-# If you disable it, Brigade will still process events, but extra tooling (like
-# brig) may not be able to learn about it.
+## api is the API server. It is technically not needed for the operation of the
+## Brigade controller, but it is used by tools to learn about the state of the
+## cluster.
+##
+## If you disable it, Brigade will still process events, but extra tooling (like
+## brig) may not be able to learn about it.
 api:
   enabled: true
   registry: brigadecore
@@ -116,12 +116,12 @@ api:
     type: ClusterIP
     externalPort: 7745
     internalPort: 7745
-  # Configure liveness probes except `httpGet`
-  #livenessProbe:
-  #  initialDelaySeconds: 20
-  # Configure readiness probes except `httpGet`
-  #readinessProbe:
-  #  initialDelaySeconds: 20
+  ## Configure liveness probes except `httpGet`
+  # livenessProbe:
+  #   initialDelaySeconds: 20
+  ## Configure readiness probes except `httpGet`
+  # readinessProbe:
+  #   initialDelaySeconds: 20
   ingress:
     enabled: false
     hosts: []
@@ -131,55 +131,55 @@ api:
     create: true
     name: 
 
-# worker is the JavaScript worker. These are created on demand by the controller.
+## worker is the JavaScript worker. These are created on demand by the controller.
 worker:
   registry: brigadecore
   name: brigade-worker
-  #command:
+  # command:
   serviceAccount: 
     create: true
     name: brigade-worker
-  #tag:
-  #pullPolicy: IfNotPresent
-  #defaultBuildStorageClass:
-  #defaultCacheStorageClass:
+  # tag:
+  # pullPolicy: IfNotPresent
+  # defaultBuildStorageClass:
+  # defaultCacheStorageClass:
 
 
-# These values are for the Container Registry (CR) gateway.
-# Enabling this will start a service that handles webhooks from container
-# registries like DockerHub and ACR. Note that these registries do not have
-# strong auth built in, so enabling this gateway could result in repeated
-# bogus requests from an unauthenticated source. This could pose a security
-# risk for poorly written scripts, and could be an opening for DOS-style
-# attacks on your cluster.
+## These values are for the Container Registry (CR) gateway.
+## Enabling this will start a service that handles webhooks from container
+## registries like DockerHub and ACR. Note that these registries do not have
+## strong auth built in, so enabling this gateway could result in repeated
+## bogus requests from an unauthenticated source. This could pose a security
+## risk for poorly written scripts, and could be an opening for DOS-style
+## attacks on your cluster.
 cr:
   enabled: false
   registry: brigadecore
   name: brigade-cr-gateway
-  #tag: latest
+  # tag: latest
   service:
     name: brigade-cr-service
     type: ClusterIP  # Change to LoadBalancer if you want this externally available.
     externalPort: 80
     internalPort: 8000
-  # Configure liveness probes except `httpGet`
-  #livenessProbe:
-  #  initialDelaySeconds: 20
-  # Configure readiness probes except `httpGet`
-  #readinessProbe:
-  #  initialDelaySeconds: 20
+  ## Configure liveness probes except `httpGet`
+  # livenessProbe:
+  #   initialDelaySeconds: 20
+  ## Configure readiness probes except `httpGet`
+  # readinessProbe:
+  #   initialDelaySeconds: 20
   serviceAccount:
     create: true
     name: 
 
-# These values are for the Generic Gateway.
-# Enabling this will start a service that handles webhooks from external clients. 
-# To call this endpoint you need a special secret value that is configured once per project.
+## These values are for the Generic Gateway.
+## Enabling this will start a service that handles webhooks from external clients. 
+## To call this endpoint you need a special secret value that is configured once per project.
 genericGateway:
   enabled: false
   registry: brigadecore
   name: brigade-generic-gateway
-  #tag: latest
+  # tag: latest
   service:
     name: brigade-generic-service
     type: ClusterIP  # Change to LoadBalancer if you want this externally available.
@@ -191,12 +191,12 @@ genericGateway:
   ingress:
     enabled: false
 
-    # use the correct annotation for your certificate provider
-    # the following config works according to the Brigade docs
-    # which show how to use Nginx Ingress Controller and cert-manager
-    #
-    # Note: if you delete the ingress resource and re-create it on the same subdomain, make sure
-    # to delete the secret before trying again.
+    ## use the correct annotation for your certificate provider
+    ## the following config works according to the Brigade docs
+    ## which show how to use Nginx Ingress Controller and cert-manager
+    ##
+    ## Note: if you delete the ingress resource and re-create it on the same subdomain, make sure
+    ## to delete the secret before trying again.
 
     # annotations:
     #   kubernetes.io/ingress.class: "nginx"    
@@ -204,49 +204,49 @@ genericGateway:
     #   certmanager.k8s.io/acme-challenge-type: http01
 
     # hosts:
-    #   - brigade-events.subdomain.domain.com
+    # - brigade-events.subdomain.domain.com
     # paths:
     # - /
     # tls:
-    #   - secretName: brigade-events
-    #     hosts:
-    #     - brigade-events.subdomain.domain.com
+    # - secretName: brigade-events
+    #   hosts:
+    #   - brigade-events.subdomain.domain.com
 
 
-# The vacuum periodically cleans up old builds.
-# Brigade does not delete builds on completion. Instead, it leaves builds around
-# for a period of time, providing you with an opportunity to inspect builds for
-# data.
-# The vacuum will sweep the system at intervals and clear out old builds.
-#
-# To globally turn of the vacuum, set enabled=false
+## The vacuum periodically cleans up old builds.
+## Brigade does not delete builds on completion. Instead, it leaves builds around
+## for a period of time, providing you with an opportunity to inspect builds for
+## data.
+## The vacuum will sweep the system at intervals and clear out old builds.
+##
+## To globally turn of the vacuum, set enabled=false
 vacuum:
   enabled: true
-  # Set a schedule for how frequently this check is run.
-  # Note that a run of the vacuum typically takes at least a minute. Finer-level
-  # granularity than that may result in multiple vacuums running at once.
-  # Format follows accepted Cron formats: https://en.wikipedia.org/wiki/Cron
+  ## Set a schedule for how frequently this check is run.
+  ## Note that a run of the vacuum typically takes at least a minute. Finer-level
+  ## granularity than that may result in multiple vacuums running at once.
+  ## Format follows accepted Cron formats: https://en.wikipedia.org/wiki/Cron
   schedule: "@hourly"
   registry: "brigadecore"
   name: "brigade-vacuum"
   # tag: latest
-  # Age tells the vacuum how old a thing may be before it is considered ready to
-  # be vacuumed. The format is an integer followed by the suffix h (hours), m (minutes)
-  # or s (seconds).
-  # The default is 30 days (720 hours)
+  ## Age tells the vacuum how old a thing may be before it is considered ready to
+  ## be vacuumed. The format is an integer followed by the suffix h (hours), m (minutes)
+  ## or s (seconds).
+  ## The default is 30 days (720 hours)
   age: "720h"
-  # maxBuilds tells the vacuum what the absolute maximum number of builds may be stored
-  # at a time. Where possible, we recommend using age rather than builds.
-  # -1 means no limit is imposed.
-  #
-  # If both age and maxBuilds are provided, age is applied first, then maxBuilds.
+  ## maxBuilds tells the vacuum what the absolute maximum number of builds may be stored
+  ## at a time. Where possible, we recommend using age rather than builds.
+  ## -1 means no limit is imposed.
+  ##
+  ## If both age and maxBuilds are provided, age is applied first, then maxBuilds.
   maxBuilds: -1
   serviceAccount:
     create: true
     name: 
 
 
-# DEVELOPMENT ONLY: Use this for off-ACS development
-# Before enabling this, log into the acr registry with Docker and then
-# run `scripts/generate-acr-secret.sh`
-#privateRegistry: brigade-registry
+## DEVELOPMENT ONLY: Use this for off-ACS development
+## Before enabling this, log into the acr registry with Docker and then
+## run `scripts/generate-acr-secret.sh`
+# privateRegistry: brigade-registry

--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -1,7 +1,7 @@
 brigade:
-  # This value defaults to one derived from the context of a release,
-  # and assumes this chart has been deployed in tandem with the brigade chart.
-  # If this is not the case, one can supply a non-default value here.
+  ## This value defaults to one derived from the context of a release,
+  ## and assumes this chart has been deployed in tandem with the brigade chart.
+  ## If this is not the case, one can supply a non-default value here.
   apiServer:
 
 replicaCount: 1
@@ -16,25 +16,25 @@ service:
   internalPort: 80
 ingress:
   enabled: false
-  # Used to create Ingress record (should used with service.type: ClusterIP).
+  ## Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
-    - chart-example.local
+  - chart-example.local
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  ## Secrets must be manually created in the namespace.
+  # - secretName: chart-example-tls
+  #   hosts:
+  #   - chart-example.local
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  #requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi


### PR DESCRIPTION
Fixes #16 

_Also_ fixes makes indentation of lists more consistent.

This is acceptable:

```
list:
  - item1
  - item2
```

But this is generally preferred throughout the k8s community:

```
list:
- item1
- item2
```

In either event, one convention should be chosen and applied consistently. Both were in use, now there is just one.