### PR TITLE
feat(charts/brigade-github-app): add/use appVersion default

### DIFF
--- a/charts/brigade-github-app/Chart.yaml
+++ b/charts/brigade-github-app/Chart.yaml
@@ -4,3 +4,5 @@ name: brigade-github-app
 sources:
   - https://github.com/brigadecore/brigade-github-app
 version: 0.0.1
+# Note that we use appVersion to get images, so make sure this is correct.
+appVersion: v0.1.0

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -9,8 +9,9 @@ serviceAccount:
 ## Image configuration
 registry: brigadecore
 name: brigade-github-app
-tag: latest
-pullPolicy: "Always"
+## Image tags in this chart default to the value specified by appVersion in Chart.yaml
+# tag: latest
+# pullPolicy: "Always"
 
 service:
   name: brigade-github-app


### PR DESCRIPTION
This updates the `brigade-github-app` chart to use `appVersion` in the `Chart.yaml` file for the corresponding image tag value.  Note the particular value used here derives from: https://github.com/brigadecore/brigade-github-app/releases/tag/v0.1.0