### PR TITLE
chore(charts/brigade): bump brigade-github-app sub-chart version

### DIFF
--- a/charts/brigade/requirements.lock
+++ b/charts/brigade/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.1
 - name: brigade-github-app
   repository: https://brigadecore.github.io/charts
-  version: 0.1.2
+  version: 0.2.0
 - name: brigade-github-oauth
   repository: https://brigadecore.github.io/charts
   version: 0.1.0
-digest: sha256:ff6dc1e799179709e6d4d2c713c7dcd4934f547a83cd6248174e8e06e1519efa
-generated: 2019-03-26T13:08:19.493814-06:00
+digest: sha256:5619a92c36e6c6e81d11a29dfe638ee5fb7f1084ca912b6d032ac89680d96c97
+generated: 2019-06-04T15:31:03.418151-06:00

--- a/charts/brigade/requirements.yaml
+++ b/charts/brigade/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://brigadecore.github.io/charts
     condition: kashti.enabled
   - name: brigade-github-app
-    version: 0.1.2
+    version: 0.2.0
     repository: https://brigadecore.github.io/charts
     condition: brigade-github-app.enabled
   - name: brigade-github-oauth


### PR DESCRIPTION
Bump the `brigade-github-app` sub-chart version to latest `0.2.0` for the main `brigade` chart.