### PR TITLE
surface the defaultSharedSecret option for the github gateway

### DIFF
--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -58,6 +58,11 @@ kashti:
 ## For full configuration, see the brigade-github-app chart in this repository
 brigade-github-app:
   enabled: false
+  github:
+    ## Set a defaultSharedSecret if you want to use this one instance of the
+    ## Github gateway with multiple Brigade projects. Leave the shared secret
+    ## field blank in project-level configuration and this default will be used.
+    # defaultSharedSecret:
 
 ## gw is the deprecated Oauth-based GitHub Gateway that shipped with Brigade <= v0.20
 ##


### PR DESCRIPTION
I suppose technically, this doesn't need to be here to be accessible / configurable, but I'm well enough convinced that this is a good thing to do that I'd like it to make an explicit appearance here to encourage it.