### PR TITLE
Update roles and default RBAC for gateways

### DIFF
--- a/charts/brigade-github-app/templates/gateway-role.yaml
+++ b/charts/brigade-github-app/templates/gateway-role.yaml
@@ -24,7 +24,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "pods"]
   verbs: ["list", "watch", "get", "create"]
 - apiGroups: [""]
   resources: ["*"]

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -1,6 +1,5 @@
 rbac:
-  ## Set this to true to enable Kubernetes RBAC support (recommended)
-  enabled: false
+  enabled: true
 
 serviceAccount:
   create: true

--- a/charts/brigade-github-oauth/templates/gateway-github-role.yaml
+++ b/charts/brigade-github-oauth/templates/gateway-github-role.yaml
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "pods"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/brigade-k8s-gateway/templates/gateway-role.yaml
+++ b/charts/brigade-k8s-gateway/templates/gateway-role.yaml
@@ -21,7 +21,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "pods"]
   verbs: ["list", "watch", "get", "create"]
 - apiGroups: [""]
   resources: ["*"]

--- a/charts/brigade-k8s-gateway/values.yaml
+++ b/charts/brigade-k8s-gateway/values.yaml
@@ -1,6 +1,5 @@
 rbac:
-  ## Set this to true to enable Kubernetes RBAC support (recommended)
-  enabled: false
+  enabled: true
 
 ## Image configuration
 registry: brigadecore

--- a/charts/brigade/templates/gateway-generic-role.yaml
+++ b/charts/brigade/templates/gateway-generic-role.yaml
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "pods"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
This PR updates the roles for the gateways and the default RBAC for GitHub and Kubernetes gateways.

Draft because the versions for the changed charts haven't been bumped yet - pinging @vdice for some guidance here - should we just increase the minor version for all changed charts, and then change it in the requirements file?