### PR TITLE
chore(charts/brigade): bump appVersion and sub-chart versions for 1.1.0

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -3,4 +3,4 @@ description: Brigade provides event-driven scripting of Kubernetes pipelines.
 name: brigade
 version: 0.0.1
 # Note that we use appVersion to get images, so make sure this is correct.
-appVersion: v1.0.0
+appVersion: v1.1.0

--- a/charts/brigade/requirements.lock
+++ b/charts/brigade/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.1
 - name: brigade-github-app
   repository: https://brigadecore.github.io/charts
-  version: 0.2.0
+  version: 0.3.0
 - name: brigade-github-oauth
   repository: https://brigadecore.github.io/charts
-  version: 0.1.0
-digest: sha256:5619a92c36e6c6e81d11a29dfe638ee5fb7f1084ca912b6d032ac89680d96c97
-generated: 2019-06-04T15:31:03.418151-06:00
+  version: 0.2.0
+digest: sha256:ce4c2a72514aecf7579eb75845761e207f3f543a81d3e142fb455b821721c689
+generated: "2019-06-19T10:46:55.239072-06:00"

--- a/charts/brigade/requirements.yaml
+++ b/charts/brigade/requirements.yaml
@@ -4,11 +4,11 @@ dependencies:
     repository: https://brigadecore.github.io/charts
     condition: kashti.enabled
   - name: brigade-github-app
-    version: 0.2.0
+    version: 0.3.0
     repository: https://brigadecore.github.io/charts
     condition: brigade-github-app.enabled
   - name: brigade-github-oauth
     alias: gw
-    version: 0.1.0
+    version: 0.2.0
     repository: https://brigadecore.github.io/charts
     condition: gw.enabled


### PR DESCRIPTION
* Bumps the appVersion for the main brigade chart to the latest [v1.1.0](https://github.com/brigadecore/brigade/releases/tag/v1.1.0) release
* Bumps brigade sub-chart versions according to recent releases from work in https://github.com/brigadecore/charts/pull/26