### PR TITLE
feat(charts/brigade-github-app): optional list of emitted events

### DIFF
--- a/charts/brigade-github-app/templates/deployment.yaml
+++ b/charts/brigade-github-app/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: BRIGADE_AUTHORS
             value: {{ if .Values.gateway.allowedAuthorRoles }}{{ join "," .Values.gateway.allowedAuthorRoles | quote }}{{ end }}
+          - name: BRIGADE_EVENTS
+            value: {{ if .Values.gateway.emittedEvents }}{{ join "," .Values.gateway.emittedEvents | quote }}{{ end }}
           - name: GATEWAY_CONFIG
             value: "/etc/brigade-github-app/key.pem"
           - name: APP_ID

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -41,6 +41,13 @@ gateway:
   - OWNER
   - MEMBER
   - COLLABORATOR
+  ## The opt-in list of events to be emitted
+  ## Brigade creates one or two worker pods for each webhook request so
+  ## ignoring unnecessary events saves your cluster's resource.
+  ## Defaults to "*" that matches any event type and action.
+  ## Remove "*" and set qualified(e.g. `issue_comment:created`) or unqualified(e.g. `issue_comment`) events instead so that Brigade emit creates worker pods for those events only.
+  emittedEvents:
+  - "*"
 
 github:
   ## The x509 PEM-formatted keyfile GitHub issued for you App.


### PR DESCRIPTION
This exposes https://github.com/brigadecore/brigade-github-app/pull/74 to the chart so that the list is configurable via chart values.

Ref https://github.com/brigadecore/brigade-github-app/issues/37