### PR TITLE
use latest kashti subchart

### DIFF
--- a/charts/brigade/requirements.lock
+++ b/charts/brigade/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kashti
   repository: https://brigadecore.github.io/charts
-  version: 0.1.1
+  version: 0.3.0
 - name: brigade-github-app
   repository: https://brigadecore.github.io/charts
   version: 0.3.0
 - name: brigade-github-oauth
   repository: https://brigadecore.github.io/charts
   version: 0.2.0
-digest: sha256:ce4c2a72514aecf7579eb75845761e207f3f543a81d3e142fb455b821721c689
-generated: "2019-06-19T10:46:55.239072-06:00"
+digest: sha256:df1ec3d70eca0e39079b21cfbbdd6a7b82190d2210e05fedd7a4ccb19433d1f0
+generated: 2019-07-30T13:37:51.573268-04:00

--- a/charts/brigade/requirements.yaml
+++ b/charts/brigade/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: kashti
-    version: 0.1.1
+    version: 0.3.0
     repository: https://brigadecore.github.io/charts
     condition: kashti.enabled
   - name: brigade-github-app


### PR DESCRIPTION
Update brigade chart to use latest Kashti sub-schart (v0.3.0).