### PR TITLE
fix placeholder version in kashti's Chart.yaml

### DIFF
--- a/charts/kashti/Chart.yaml
+++ b/charts/kashti/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kashti
-version: 0.3.0
+version: 0.0.1
 appVersion: v0.3.0


### PR DESCRIPTION
This fixes a minor goof in #30 

I had forgotten that the version field in this file is a placeholder only and the correct version number is derived from the git tag and inserted automatically as part of the release process.

There was no fallout from this mistake, but I still want to correct it so that it's consistent with the other charts in this repository.