### PR TITLE
chore(charts/brigade): bump appVersion to v1.2.0

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -3,4 +3,4 @@ description: Brigade provides event-driven scripting of Kubernetes pipelines.
 name: brigade
 version: 0.0.1
 # Note that we use appVersion to get images, so make sure this is correct.
-appVersion: v1.2.0-beta.2
+appVersion: v1.2.0


### PR DESCRIPTION
Bump the `appVersion` in the Brigade chart per https://github.com/brigadecore/brigade/releases/tag/v1.2.0.

The chart will be tagged/released as `1.3.0` after this is merged.