### PR TITLE
feat(charts): enable adding annotations to deployment pods

### DIFF
--- a/charts/brigade-github-app/templates/deployment.yaml
+++ b/charts/brigade-github-app/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app: {{ $fullname }}
         role: gateway

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -63,3 +63,7 @@ github:
   ## Github gateway with multiple Brigade projects. Leave the shared secret field
   ## blank in project-level configuration and this default will be used.
   # defaultSharedSecret:
+
+  ## Add custom annotations to the api pod
+  # podAnnotations:
+  #   name: value

--- a/charts/brigade-github-oauth/templates/gateway-github-deployment.yaml
+++ b/charts/brigade-github-oauth/templates/gateway-github-deployment.yaml
@@ -15,6 +15,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "gateway.legacyappname" . }}
         app: {{ include "gateway.legacyappname" . }}

--- a/charts/brigade-github-oauth/values.yaml
+++ b/charts/brigade-github-oauth/values.yaml
@@ -47,3 +47,7 @@ ingress:
   ## Add custom annotations
   # annotations:
   #   name: value
+
+## Add custom annotations to the pod
+# podAnnotations:
+#   name: value

--- a/charts/brigade-k8s-gateway/templates/deployment.yaml
+++ b/charts/brigade-k8s-gateway/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app: {{ $fullname }}
         role: gateway

--- a/charts/brigade-k8s-gateway/values.yaml
+++ b/charts/brigade-k8s-gateway/values.yaml
@@ -7,6 +7,10 @@ name: brigade-k8s-gateway
 tag: latest
 pullPolicy: "IfNotPresent"
 
+## Add custom annotations to the pod
+# podAnnotations:
+#   name: value
+
 ## What to watch
 project: brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac
 

--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -15,6 +15,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.api.podAnnotations }}
+      annotations:
+{{ toYaml .Values.api.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "brigade.fullname" . }}-api
         app: {{ template "brigade.fullname" . }}-api

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -14,6 +14,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.controller.podAnnotations }}
+      annotations:
+{{ toYaml .Values.controller.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ $fullname }}
         app: {{ $fullname }}

--- a/charts/brigade/templates/gateway-cr-deployment.yaml
+++ b/charts/brigade/templates/gateway-cr-deployment.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.cr.podAnnotations }}
+      annotations:
+{{ toYaml .Values.cr.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "brigade.fullname" . }}
         app: {{ template "brigade.fullname" . }}

--- a/charts/brigade/templates/gateway-generic-deployment.yaml
+++ b/charts/brigade/templates/gateway-generic-deployment.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.genericGateway.podAnnotations }}
+      annotations:
+{{ toYaml .Values.genericGateway.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "brigade.fullname" . }}
         app: {{ template "brigade.fullname" . }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -104,6 +104,9 @@ controller:
   serviceAccount:
     create: true
     name: 
+  ## Add custom annotations to the controller pod
+  # podAnnotations:
+  #   name: value
 
 ## api is the API server. It is technically not needed for the operation of the
 ## Brigade controller, but it is used by tools to learn about the state of the
@@ -135,6 +138,9 @@ api:
   serviceAccount:
     create: true
     name: 
+  ## Add custom annotations to the api pod
+  # podAnnotations:
+  #   name: value
 
 ## worker is the JavaScript worker. These are created on demand by the controller.
 worker:
@@ -176,6 +182,9 @@ cr:
   serviceAccount:
     create: true
     name: 
+  ## Add custom annotations to the cr gateway pod
+  # podAnnotations:
+  #   name: value
 
 ## These values are for the Generic Gateway.
 ## Enabling this will start a service that handles webhooks from external clients. 
@@ -196,6 +205,9 @@ genericGateway:
     name:
   ingress:
     enabled: false
+  ## Add custom annotations to the generic gateway pod
+  # podAnnotations:
+  #   name: value
 
     ## use the correct annotation for your certificate provider
     ## the following config works according to the Brigade docs

--- a/charts/kashti/templates/deployment.yaml
+++ b/charts/kashti/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       annotations:
         checksum/config-js: {{ include (print $.Template.BasePath "/js-configmap.yaml") . | sha256sum }}
         checksum/config-nginx: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+    {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -40,3 +40,7 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+## Add custom annotations to the kashti pod
+# podAnnotations:
+#   name: value


### PR DESCRIPTION
Adds ability to add custom annotations to most deployment pods, for applicable charts.

As an example, one may wish to inject Linkerd to a given pod via:
```
podAnnotations:
  linkerd.io/inject: enabled
```

Or perhaps tell Prometheus not to scrape stats:
```
podAnnotations:
  prometheus.io/scrape: 'false'
```

Etc.
