### PR TITLE
feat(brigade-project): enable setting default config values

### DIFF
--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -22,6 +22,12 @@ stringData:
   {{ if .Values.defaultScript }}
   defaultScript: |
 {{.Values.defaultScript | indent 4}}
+  {{ if .Values.defaultConfigName }}
+  defaultConfigName: {{ .Values.defaultConfigName | quote }}
+  {{- end }}
+  {{ if .Values.defaultConfig }}
+  defaultConfig: |
+{{.Values.defaultConfig | indent 4}}
   {{- end }}
   {{ if empty .Values.vcsSidecar }}
   vcsSidecar: {{ printf "brigadecore/git-sidecar:%s" .Chart.AppVersion }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -23,6 +23,17 @@ cloneURL: "https://github.com/brigadecore/empty-testbed.git"
 ## OPTIONAL: defaultScriptName is the name of a configmap used as a fallback brigade.js.
 # defaultScriptName: default-script-cm
 
+## OPTIONAL: defaultConfig is the brigade.json config used by default when your VCS repo has none
+# defaultConfig: |
+#   {
+#     "dependencies": {
+#         "@brigadecore/brigade-utils": "0.3.0"
+#     }
+#   }
+
+## OPTIONAL: defaultConfigName is the name of a configmap used as a fallback brigade.js.
+# defaultConfigName: default-config-cm
+
 
 ## Used by GitHub and other services to compute hook HMACs.
 sharedSecret: "IBrakeForSeaBeasts"


### PR DESCRIPTION
Enables setting `defaultConfig` and `defaultConfigName` values as added in https://github.com/brigadecore/brigade/pull/1030

Depends on https://github.com/brigadecore/brigade/pull/1030