### PR TITLE
ref(*): k8s api updates/conditionals per 1.16.x

### DIFF
--- a/charts/brigade-github-app/templates/_helpers.tpl
+++ b/charts/brigade-github-app/templates/_helpers.tpl
@@ -15,4 +15,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1beta1{{ end -}}
+{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1{{ end -}}
+
+{{/*
+Return the appropriate apiVersion for a deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/brigade-github-app/templates/deployment.yaml
+++ b/charts/brigade-github-app/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{ $fullname :=  include "gateway.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -13,6 +13,12 @@ metadata:
     type: github-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullname }}
+      role: gateway
+      release: "{{ .Release.Name }}"
+      type: github-app
   template:
     metadata:
     {{- if .Values.podAnnotations }}

--- a/charts/brigade-github-app/templates/ingress.yaml
+++ b/charts/brigade-github-app/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "gateway.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "gateway.fullname" . }}

--- a/charts/brigade-github-oauth/templates/_helpers.tpl
+++ b/charts/brigade-github-oauth/templates/_helpers.tpl
@@ -18,4 +18,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-brigade" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1beta1{{ end -}}
+{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1{{ end -}}
+
+{{/*
+Return the appropriate apiVersion for a deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/brigade-github-oauth/templates/gateway-github-deployment.yaml
+++ b/charts/brigade-github-oauth/templates/gateway-github-deployment.yaml
@@ -1,6 +1,6 @@
 {{ $fullname := include "gateway.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -13,6 +13,12 @@ metadata:
     type: github
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gateway.legacyappname" . }}
+      app: {{ include "gateway.legacyappname" . }}
+      role: gateway
+      type: github
   template:
     metadata:
     {{- if .Values.podAnnotations }}

--- a/charts/brigade-github-oauth/templates/ingress.yaml
+++ b/charts/brigade-github-oauth/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "gateway.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $paths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $serviceName }}

--- a/charts/brigade-k8s-gateway/templates/_helpers.tpl
+++ b/charts/brigade-k8s-gateway/templates/_helpers.tpl
@@ -15,4 +15,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1beta1{{ end -}}
+{{- define "gateway.rbac.version" }}rbac.authorization.k8s.io/v1{{ end -}}
+
+{{/*
+Return the appropriate apiVersion for a deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/brigade-k8s-gateway/templates/deployment.yaml
+++ b/charts/brigade-k8s-gateway/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $fullname :=  include "gateway.fullname" . }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -12,6 +12,11 @@ metadata:
     type: kubernetes-events
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $fullname }}
+      role: gateway
+      type: kubernetes-events
   template:
     metadata:
     {{- if .Values.podAnnotations }}

--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -34,4 +34,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ include "brigade.fullname" . | printf "%s-vacuum" }}
 {{- end -}}
 
-{{- define "brigade.rbac.version" }}rbac.authorization.k8s.io/v1beta1{{ end -}}
+{{- define "brigade.rbac.version" }}rbac.authorization.k8s.io/v1{{ end -}}
+
+{{/*
+Return the appropriate apiVersion for a deployment
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.api.enabled }}
 {{ $fullname := include "brigade.api.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.api.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "brigade.fullname" . }}-api
@@ -13,6 +13,11 @@ metadata:
     role: api
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "brigade.fullname" . }}-api
+      app: {{ template "brigade.fullname" . }}-api
+      role: api
   template:
     metadata:
     {{- if .Values.api.podAnnotations }}

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.controller.enabled }}{{ $fullname := include "brigade.ctrl.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.controller.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -12,6 +12,11 @@ metadata:
     role: controller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $fullname }}
+      app: {{ $fullname }}
+      role: controller
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}

--- a/charts/brigade/templates/gateway-cr-deployment.yaml
+++ b/charts/brigade/templates/gateway-cr-deployment.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.cr.enabled }}
 {{ $fullname := include "brigade.cr.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.cr.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -14,6 +14,12 @@ metadata:
     type: dockerhub
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "brigade.fullname" . }}
+      app: {{ template "brigade.fullname" . }}
+      role: gateway
+      type: dockerhub
   template:
     metadata:
     {{- if .Values.cr.podAnnotations }}

--- a/charts/brigade/templates/gateway-generic-deployment.yaml
+++ b/charts/brigade/templates/gateway-generic-deployment.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.genericGateway.enabled }}
 {{ $fullname := include "brigade.genericGateway.fullname" . }}
 {{ $serviceAccount := default $fullname .Values.genericGateway.serviceAccount.name }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullname }}
@@ -14,6 +14,12 @@ metadata:
     type: generic
 spec:
   replicas: 1
+  selector:
+    matchlabels:
+      app.kubernetes.io/name: {{ template "brigade.fullname" . }}
+      app: {{ template "brigade.fullname" . }}
+      role: gateway
+      type: generic
   template:
     metadata:
     {{- if .Values.genericGateway.podAnnotations }}

--- a/charts/brigade/templates/gateway-generic-ingress.yaml
+++ b/charts/brigade/templates/gateway-generic-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "brigade.genericGateway.fullname" . -}}
 {{- $servicePort := .Values.genericGateway.service.externalPort -}}
 {{- $paths := .Values.genericGateway.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $serviceName }}

--- a/charts/kashti/templates/_helpers.tpl
+++ b/charts/kashti/templates/_helpers.tpl
@@ -18,3 +18,25 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "brigade.apiServer" -}}
 {{- printf "http://%s-brigade-api:7745" .Release.Name -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kashti/templates/deployment.yaml
+++ b/charts/kashti/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/charts/kashti/templates/ingress.yaml
+++ b/charts/kashti/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
Updates per the Kubernetes [v1.16.0 release](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals), including:

 - conditional `apiVersion` values based on k8s cluster version, for deployment and networking (ingress) objects
 - addition of `spec.selector.matchLabels` entries (now required) for deployments per https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment
 - update of the RBAC `apiVersion` to `rbac.authorization.k8s.io/v1` which appears to have been overdue since v1.8.x (https://kubernetes.io/docs/reference/access-authn-authz/rbac/)

TODO
 - [x] Test installation on k8s cluster >= 1.16.0
 - [x] Test installation on k8s cluster < 1.16.0, including < 1.14.0

A note on cutting new versions of charts once this PR is merged.  We'll

1. Cut new versions of all standalone charts (with no chart dependencies)
2. Create and merge a PR bumping the sub-chart versions in the main Brigade chart's `requirements.yaml`
3. Cut a new version of the main Brigade chart

Closes https://github.com/brigadecore/charts/issues/54