### PR TITLE
fix(charts/brigade): use apiVersion template value for api ingress object

### DIFF
--- a/charts/brigade/templates/api-ingress.yaml
+++ b/charts/brigade/templates/api-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "brigade.api.fullname" . -}}
 {{- $servicePort := .Values.api.service.externalPort -}}
 {{- $paths := .Values.api.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $serviceName }}


### PR DESCRIPTION
Adds an `apiVersion` update missing from https://github.com/brigadecore/charts/pull/55 