### PR TITLE
fix(charts/brigade): s/matchlabels/matchLabels

### DIFF
--- a/charts/brigade/templates/gateway-generic-deployment.yaml
+++ b/charts/brigade/templates/gateway-generic-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchlabels:
+    matchLabels:
       app.kubernetes.io/name: {{ template "brigade.fullname" . }}
       app: {{ template "brigade.fullname" . }}
       role: gateway


### PR DESCRIPTION
😅 fixes typo for `matchLabels` section on generic gateway deployment
