### PR TITLE
brigade-project: remove unused section of values.yaml with misleading comment

### DIFF
--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -82,11 +82,6 @@ secrets:
   ## Example:
   # username: hello
 
-## OPTIONAL: Namespace into which builds will be deployed.
-## Using this has implications for what you can access, so don't set this unless
-## you know what you are doing.
-# namespace: "default"
-
 ## OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
 ## The default sidecar uses Git to fetch a copy of the project.
 ##


### PR DESCRIPTION
This is not used anywhere else in the chart and it hints at a feature that Brigade does not have-- the ability to run builds in different namespaces. It seems this is vestigial from a time when that feature was considered.