### PR TITLE
fix(Makefile): properly capture and return exit code; fix chart test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ endif
 define all-charts
 	@for chart in $$(ls -1 $(CHARTS_DIR)); do \
 		CHART=$$chart make $(MAKE_OPTS) $(1) ; \
+		exit_code=$$? ; \
+		if [[ $$exit_code -ne 0 ]] ; then \
+			exit $$exit_code ; \
+		fi ; \
 	done
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,7 @@ endif
 # all-charts loops through all charts and runs the make target(s) provided
 define all-charts
 	@for chart in $$(ls -1 $(CHARTS_DIR)); do \
-		CHART=$$chart make $(MAKE_OPTS) $(1) ; \
-		exit_code=$$? ; \
-		if [[ $$exit_code -ne 0 ]] ; then \
-			exit $$exit_code ; \
-		fi ; \
+		CHART=$$chart make $(MAKE_OPTS) $(1) || exit $$? ; \
 	done
 endef
 

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -22,6 +22,7 @@ stringData:
   {{ if .Values.defaultScript }}
   defaultScript: |
 {{.Values.defaultScript | indent 4}}
+  {{- end }}
   {{ if .Values.defaultConfigName }}
   defaultConfigName: {{ .Values.defaultConfigName | quote }}
   {{- end }}


### PR DESCRIPTION
- Discovered a bug in our Makefile logic when iterating over the charts to run a target; we weren't properly capturing and returning the exit code

- Fixes an error from linting the charts:

```
 $ make test
==> Linting ./charts/brigade
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
==> Linting ./charts/brigade-github-app
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
==> Linting ./charts/brigade-github-oauth
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
==> Linting ./charts/brigade-k8s-gateway
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
==> Linting ./charts/brigade-project
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: parse error in "brigade-project/templates/secret.yaml": template: brigade-project/templates/secret.yaml:76: unexpected EOF

Error: 1 chart(s) linted, 1 chart(s) failed
make[1]: *** [test] Error 1
make: *** [test] Error 2
```