### PR TITLE
chore(charts/brigade): bump appVersion to latest release

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -3,4 +3,4 @@ description: Brigade provides event-driven scripting of Kubernetes pipelines.
 name: brigade
 version: 0.0.1
 # Note that we use appVersion to get images, so make sure this is correct.
-appVersion: v1.2.1
+appVersion: v1.3.0


### PR DESCRIPTION
Bumps the appVersion for the Brigade chart to the latest [v1.3.0](https://github.com/brigadecore/brigade/releases/tag/v1.3.0) release.