### PR TITLE
feat(charts/brigade-github-app): bump version

### DIFF
--- a/charts/brigade-github-app/Chart.yaml
+++ b/charts/brigade-github-app/Chart.yaml
@@ -5,4 +5,4 @@ sources:
   - https://github.com/brigadecore/brigade-github-app
 version: 0.0.1
 # Note that we use appVersion to get images, so make sure this is correct.
-appVersion: v0.4.0
+appVersion: v0.4.1


### PR DESCRIPTION
Picks up the latest release of the Brigade GitHub App: https://github.com/brigadecore/brigade-github-app/releases/tag/v0.4.1

Once merged, the intention is to tag the chart with a patch-incremented value.  In this case, `v0.7.1`.  A follow-up to bump to this new version will be submitted to the main Brigade chart.