### PR TITLE
chore(ci): pin gh-pages to known working version

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -51,7 +51,7 @@ function publish(e, project) {
   publisher.storage.enabled = true;
 
   publisher.tasks = [
-    "npm install -g gh-pages",
+    "npm install -g gh-pages@3.0.0",
     "cd /src",
     `cp -a ${sharedMountPrefix}/dist .`,
     `gh-pages --add -d dist \


### PR DESCRIPTION
The most recent chart release initially failed, seemingly due to https://github.com/tschaub/gh-pages/issues/354:

```
 $ k logs brigadecore-charts-publish-01ecx5q72k8j4wj3gcqkxb5834
/usr/local/bin/gh-pages -> /usr/local/lib/node_modules/gh-pages/bin/gh-pages.js
/usr/local/bin/gh-pages-clean -> /usr/local/lib/node_modules/gh-pages/bin/gh-pages-clean.js
+ gh-pages@3.1.0
added 52 packages from 14 contributors in 3.351s
The "path" argument must be of type string. Received undefined
```

Rerunning the job with this utility pinned to 3.0.0 worked:
```
 $ k logs brigadecore-charts-publish-01ecx77xnamn9yzr8sndjh1g35
/usr/local/bin/gh-pages -> /usr/local/lib/node_modules/gh-pages/bin/gh-pages.js
/usr/local/bin/gh-pages-clean -> /usr/local/lib/node_modules/gh-pages/bin/gh-pages-clean.js
+ gh-pages@3.0.0
added 41 packages from 14 contributors in 2.205s
Published
```