### PR TITLE
chore(charts/brigade): bump brigade-github-app sub-chart version

### DIFF
--- a/charts/brigade/requirements.lock
+++ b/charts/brigade/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.5.0
 - name: brigade-github-app
   repository: https://brigadecore.github.io/charts
-  version: 0.7.0
+  version: 0.7.1
 - name: brigade-github-oauth
   repository: https://brigadecore.github.io/charts
   version: 0.3.0
-digest: sha256:cdab19ca150a67ef60152961357400d94a2d38b02db42ea38c2ceb8b72e69b60
-generated: "2020-05-01T12:12:46.228258-04:00"
+digest: sha256:3165e5cc760211e2fa831ff0c9c5a4c6f8eeac69e79f3c355c78acf62c2b7f03
+generated: "2020-07-10T14:48:17.86525-06:00"

--- a/charts/brigade/requirements.yaml
+++ b/charts/brigade/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://brigadecore.github.io/charts
     condition: kashti.enabled
   - name: brigade-github-app
-    version: 0.7.0
+    version: 0.7.1
     repository: https://brigadecore.github.io/charts
     condition: brigade-github-app.enabled
   - name: brigade-github-oauth


### PR DESCRIPTION
Bumps the version of the brigade-github-app sub-chart version to the [latest](https://github.com/brigadecore/charts/releases/tag/brigade-github-app-v0.7.1).