### PR TITLE
add ability to add image pull secrets to service accounts

### DIFF
--- a/charts/brigade/templates/api-role.yaml
+++ b/charts/brigade/templates/api-role.yaml
@@ -12,6 +12,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.api.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ end }}
 {{ if .Values.rbac.enabled }}
 ---

--- a/charts/brigade/templates/controller-role.yaml
+++ b/charts/brigade/templates/controller-role.yaml
@@ -12,6 +12,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.controller.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ end }}
 {{ if .Values.rbac.enabled }}
 ---

--- a/charts/brigade/templates/gateway-cr-role.yaml
+++ b/charts/brigade/templates/gateway-cr-role.yaml
@@ -12,6 +12,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.cr.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ end }}
 {{ if .Values.rbac.enabled }}
 ---

--- a/charts/brigade/templates/gateway-generic-role.yaml
+++ b/charts/brigade/templates/gateway-generic-role.yaml
@@ -12,6 +12,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.genericGateway.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ end }}
 {{ if .Values.rbac.enabled }}
 ---

--- a/charts/brigade/templates/vacuum-role.yaml
+++ b/charts/brigade/templates/vacuum-role.yaml
@@ -12,6 +12,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- range $imagePullSecret := .Values.vacuum.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role

--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.worker.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -104,6 +104,7 @@ controller:
   serviceAccount:
     create: true
     name:
+    imagePullSecrets: []
   ## Add custom annotations to the controller pod
   # podAnnotations:
   #   name: value
@@ -138,6 +139,7 @@ api:
   serviceAccount:
     create: true
     name:
+    imagePullSecrets: []
   ## Add custom annotations to the api pod
   # podAnnotations:
   #   name: value
@@ -150,6 +152,15 @@ worker:
   serviceAccount:
     create: true
     name: brigade-worker
+    ## This SA is the default used by all workers and jobs unless otherwise
+    ## specified. Referencing image pull secrets (which must be created
+    ## separately) from this SA is a convenient way to ensure those image pull
+    ## secrets are available to ALL workers and jobs (or at least those using
+    ## this SA) WITHOUT needing to explicitly reference those image pull secrets
+    ## on every worker or job definition. This is useful, for instance, for
+    ## circumventing some registries' rate limits by using a paid account with
+    ## unlimited image pulls.
+    imagePullSecrets: []
   # tag:
   # pullPolicy: IfNotPresent
   # defaultBuildStorageClass:
@@ -182,6 +193,7 @@ cr:
   serviceAccount:
     create: true
     name:
+    imagePullSecrets: []
   ## Add custom annotations to the cr gateway pod
   # podAnnotations:
   #   name: value
@@ -203,6 +215,7 @@ genericGateway:
   serviceAccount:
     create: true
     name:
+    imagePullSecrets: []
   ingress:
     enabled: false
   ## Add custom annotations to the generic gateway pod
@@ -262,6 +275,7 @@ vacuum:
   serviceAccount:
     create: true
     name:
+    imagePullSecrets: []
   ## The following options have to do with cleaning up after the vacuum jobs
   ## themselves so completed jobs don't endlessly accumulate in the cluster.
   ##


### PR DESCRIPTION
Related to https://github.com/brigadecore/brigade/issues/1124

@vdice and I determined that it's not ideal for us (and probably not for any Brigade user) to have to explicitly call out the use of a specific image pull `Secret` in every job in every script if all you want to do is avoid rate-limiting across the board.

A little bit of research determined that if a `Pod`'s `ServiceAccount` references particular image pull `Secrets`, `that `Pod` is _automatically decorated to reference the same image pull `Secrets`_. [Reference](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)

Conveniently, the Brigade chart already, by default, creates `ServiceAccount`s for each of its components-- including workers and jobs.  This PR allows a user deploying Brigade to optionally add a reference to one or more image pull `Secret`s to any of the `ServiceAccount`s used by any of the Brigade components-- with special emphasis and documentation for the worker's `ServiceAccount` since that is where this capability is most useful.