### PR TITLE
feat(brigade-github-app): add imagePullSecrets

### DIFF
--- a/charts/brigade-github-app/templates/gateway-role.yaml
+++ b/charts/brigade-github-app/templates/gateway-role.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- range $imagePullSecret := .Values.serviceAccount.imagePullSecrets }}
+- name: {{ $imagePullSecret }}
+{{- end }}
 {{ end }}
 {{ if .Values.rbac.enabled }}
 ---

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -4,6 +4,7 @@ rbac:
 serviceAccount:
   create: true
   name: 
+  imagePullSecrets: []
 
 ## Image configuration
 registry: brigadecore


### PR DESCRIPTION
* Adds support for setting image pull secrets on the ServiceAccount for the Brigade GitHub App gateway, a la https://github.com/brigadecore/charts/pull/81