### PR TITLE
chore(charts/brigade): bump kashti dep

### DIFF
--- a/charts/brigade/requirements.lock
+++ b/charts/brigade/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kashti
   repository: https://brigadecore.github.io/charts
-  version: 0.5.0
+  version: 0.6.0
 - name: brigade-github-app
   repository: https://brigadecore.github.io/charts
   version: 0.7.1
 - name: brigade-github-oauth
   repository: https://brigadecore.github.io/charts
   version: 0.3.0
-digest: sha256:3165e5cc760211e2fa831ff0c9c5a4c6f8eeac69e79f3c355c78acf62c2b7f03
-generated: "2020-07-10T14:48:17.86525-06:00"
+digest: sha256:1bd185338abf2ff996f0b8d138f9c7bfd54e3c5bd39b6cae748cfb181f00230c
+generated: "2021-01-26T12:11:41.040563-07:00"

--- a/charts/brigade/requirements.yaml
+++ b/charts/brigade/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: kashti
-    version: 0.5.0
+    version: 0.6.0
     repository: https://brigadecore.github.io/charts
     condition: kashti.enabled
   - name: brigade-github-app


### PR DESCRIPTION
* Bumps Brigade's Kashti dep to its latest v0.6.0 chart release

Will proceed to cutting the next v1.8.0 tag for the Brigade chart once this is merged.