### PR TITLE
Update Ingress objects to new API versions

### DIFF
--- a/charts/brigade-github-app/templates/_helpers.tpl
+++ b/charts/brigade-github-app/templates/_helpers.tpl
@@ -34,7 +34,17 @@ Return the appropriate apiVersion for a networking object.
 {{- define "networking.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.isStable" -}}
+  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.supportIngressClassName" -}}
+  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- end -}}

--- a/charts/brigade-github-app/templates/ingress.yaml
+++ b/charts/brigade-github-app/templates/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.ingress.enabled -}}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
 {{- $serviceName := include "gateway.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 apiVersion: {{ template "networking.apiVersion" . }}
@@ -15,15 +17,28 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
+          {{- if $networkingApiIsStable }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
           - path: /
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -20,6 +20,8 @@ service:
 
 ingress:
   enabled: true
+  # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+  ingressClassName:
   ## Used to create an Ingress record.
   hosts:
   - gh-app.example.com

--- a/charts/brigade-github-oauth/templates/_helpers.tpl
+++ b/charts/brigade-github-oauth/templates/_helpers.tpl
@@ -37,7 +37,17 @@ Return the appropriate apiVersion for a networking object.
 {{- define "networking.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.isStable" -}}
+  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.supportIngressClassName" -}}
+  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- end -}}

--- a/charts/brigade-github-oauth/templates/ingress.yaml
+++ b/charts/brigade-github-oauth/templates/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.ingress.enabled -}}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
 {{- $serviceName := include "gateway.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $paths := .Values.ingress.paths -}}
@@ -16,16 +18,29 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           {{- range $path := $paths }}
+          {{- if $networkingApiIsStable }}
+          - path: {{ default "/" $path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
           - path: {{ default "/" $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
           {{- end -}}
     {{- end -}}
     {{- if .Values.ondraft }}
@@ -33,10 +48,20 @@ spec:
       http:
         paths:
           {{- range $path := $paths }}
+          {{- if $networkingApiIsStable }}
+          - path: {{ default "/" $path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
           - path: {{ default "/" $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
           {{- end -}}
     {{- end -}}
   {{- if .Values.ingress.tls }}

--- a/charts/brigade-github-oauth/values.yaml
+++ b/charts/brigade-github-oauth/values.yaml
@@ -39,6 +39,8 @@ service:
 
 ingress:
   enabled: false
+  # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+  ingressClassName:
   hosts: []
   paths:
   - /

--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -53,7 +53,17 @@ Return the appropriate apiVersion for a networking object.
 {{- define "networking.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.isStable" -}}
+  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.supportIngressClassName" -}}
+  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- end -}}

--- a/charts/brigade/templates/api-ingress.yaml
+++ b/charts/brigade/templates/api-ingress.yaml
@@ -18,8 +18,8 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- if and (.Values.api.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- range $host := .Values.api.ingress.hosts }}

--- a/charts/brigade/templates/api-ingress.yaml
+++ b/charts/brigade/templates/api-ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.api.ingress.enabled -}}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
 {{- $serviceName := include "brigade.api.fullname" . -}}
 {{- $servicePort := .Values.api.service.externalPort -}}
 {{- $paths := .Values.api.ingress.paths -}}
@@ -16,16 +18,29 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.api.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           {{- range $path := $paths }}
+          {{- if $networkingApiIsStable }}
+          - path: {{ $path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
           - path: {{ $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
           {{- end -}}
     {{- end -}}
   {{- if .Values.api.ingress.tls }}

--- a/charts/brigade/templates/gateway-generic-ingress.yaml
+++ b/charts/brigade/templates/gateway-generic-ingress.yaml
@@ -18,8 +18,8 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- if and (.Values.genericGateway.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.genericGateway.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- range $host := .Values.genericGateway.ingress.hosts }}

--- a/charts/brigade/templates/gateway-generic-ingress.yaml
+++ b/charts/brigade/templates/gateway-generic-ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.genericGateway.ingress.enabled -}}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
 {{- $serviceName := include "brigade.genericGateway.fullname" . -}}
 {{- $servicePort := .Values.genericGateway.service.externalPort -}}
 {{- $paths := .Values.genericGateway.ingress.paths -}}
@@ -16,16 +18,29 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if and (.Values.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.genericGateway.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           {{- range $path := $paths }}
+          {{- if $networkingApiIsStable }}
+          - path: {{ $path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
           - path: {{ $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
           {{- end -}}
     {{- end -}}
   {{- if .Values.genericGateway.ingress.tls }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -133,6 +133,8 @@ api:
   #   initialDelaySeconds: 20
   ingress:
     enabled: false
+    # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+    ingressClassName:
     hosts: []
     paths:
     - /
@@ -218,6 +220,8 @@ genericGateway:
     imagePullSecrets: []
   ingress:
     enabled: false
+    # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+    ingressClassName:
   ## Add custom annotations to the generic gateway pod
   # podAnnotations:
   #   name: value


### PR DESCRIPTION
This updates the Ingress object to the Kubernetes Networking API changes introduced with 1.18 and 1.19.

Kashti was implemented as a reference with #92

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>