### PR TITLE
use stable batch api if available

### DIFF
--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -67,3 +67,14 @@ Return the appropriate apiVersion for a networking object.
 {{- define "networking.apiVersion.supportIngressClassName" -}}
   {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for a batch object.
+*/}}
+{{- define "batch.apiVersion" -}}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/brigade/templates/vacuum-cronjob.yaml
+++ b/charts/brigade/templates/vacuum-cronjob.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.vacuum.enabled }}{{ $fullname := include "brigade.vacuum.fullname" .}}
 {{ $serviceAccount := default "brigade-vacuum" .Values.vacuum.serviceAccount.name }}
-apiVersion: batch/v1beta1
+apiVersion: {{ template "batch.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ $fullname }}


### PR DESCRIPTION
The `batch/v1beta1` is deprecated in k8s 1.21 and will be unavailable in 1.25+.

This change accounts for that using the same pattern that has been used to account for differences in the netowkring/ingress APIs across k8s versions.